### PR TITLE
documentation: Iterate a series of all columns

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -661,7 +661,7 @@ Get the names of the columns:
 
 Iterate a series of all columns:
 
-    for (var column in df.getColumns()) {
+    for (const column of df.getColumns()) {
         var name = column.name;
         var series = column.series;
 


### PR DESCRIPTION
df.getColumns() return iterable object. Instead of using "for ... in ...", it should be "for ... of ..." as in DataFrame class documentation.