### PR TITLE
Make DataFrame.at faster

### DIFF
--- a/src/lib/dataframe.ts
+++ b/src/lib/dataframe.ts
@@ -41,7 +41,7 @@ export interface IColumnSpec {
 }
 
 /**
- * Specifes the format per column when converting columns to strings.
+ * Specifies the format per column when converting columns to strings.
  */
 export interface IFormatSpec {
     [index: string]: string;
@@ -141,7 +141,7 @@ export interface IDataFrameConfig<IndexT, ValueT> {
     /**
      * Set to true to consider all rows/values in the dataframe when
      * determining the column names. Otherwise only the first row is considered.
-     * You should use this if you have ireggular fields in the objects that
+     * You should use this if you have irregular fields in the objects that
      * make up the rows/values of the dataframe.
      */
     considerAllRows?: boolean,
@@ -306,7 +306,7 @@ export interface IDataFrame<IndexT = number, ValueT = any> extends Iterable<Valu
      * @example
      * <pre>
      * 
-     * for (const column in df.getColummns()) {
+     * for (const column in df.getColumns()) {
      *      console.log("Column name: ");
      *      console.log(column.name);
      * 
@@ -602,7 +602,7 @@ export interface IDataFrame<IndexT = number, ValueT = any> extends Iterable<Valu
      * 
      * @param columnNames Specifies the new order for columns.
      * 
-     * @return Returns a new dataframe with columns reodered according to the order of the array of column names that is passed in.
+     * @return Returns a new dataframe with columns reordered according to the order of the array of column names that is passed in.
      * 
      * @example
      * <pre>
@@ -644,7 +644,7 @@ export interface IDataFrame<IndexT = number, ValueT = any> extends Iterable<Valu
      * 
      * @example
      * <pre>
-     * const modifiedDf = df.bringToBack(["NewSecondLastCollumn, ""NewLastColumn"]);
+     * const modifiedDf = df.bringToBack(["NewSecondLastColumn, ""NewLastColumn"]);
      * </pre>
      */
     bringToBack (columnOrColumns: string | string[]): IDataFrame<IndexT, ValueT>;
@@ -715,7 +715,7 @@ export interface IDataFrame<IndexT = number, ValueT = any> extends Iterable<Valu
      * 
      * const someObject = df.toObject(
      *      row => row.SomeColumn, // Specify the column to use for field names in the output object.
-     *      row => row.SomeOtherColumn // Specifi the column to use as the value for each field.
+     *      row => row.SomeOtherColumn // Specify the column to use as the value for each field.
      * );
      * </pre>
      */
@@ -969,7 +969,7 @@ export interface IDataFrame<IndexT = number, ValueT = any> extends Iterable<Valu
      * Eliminates adjacent duplicate rows.
      * 
      * For each group of adjacent values that are equivalent only returns the last index/row for the group, 
-     * thus ajacent equivalent rows are collapsed down to the last row.
+     * thus adjacent equivalent rows are collapsed down to the last row.
      *
      * @param [selector] Optional selector function to determine the value used to compare for equivalence.
      * 
@@ -1211,7 +1211,7 @@ export interface IDataFrame<IndexT = number, ValueT = any> extends Iterable<Valu
     /**
      * Filter the dataframe using user-defined predicate function.
      *
-     * @param predicate Predicte function to filter rows from the dataframe. Returns true/truthy to keep rows, or false/falsy to omit rows.
+     * @param predicate Predicate function to filter rows from the dataframe. Returns true/truthy to keep rows, or false/falsy to omit rows.
      * 
      * @return Returns a new dataframe containing only the rows from the original dataframe that matched the predicate. 
      * 
@@ -1224,7 +1224,7 @@ export interface IDataFrame<IndexT = number, ValueT = any> extends Iterable<Valu
     where (predicate: PredicateFn<ValueT>): IDataFrame<IndexT, ValueT>;
 
     /**
-     * Invoke a callback function for each roew in the dataframe.
+     * Invoke a callback function for each row in the dataframe.
      *
      * @param callback The calback function to invoke for each row.
      * 
@@ -1648,7 +1648,7 @@ export interface IDataFrame<IndexT = number, ValueT = any> extends Iterable<Valu
     /**
      * Collects rows in the dataframe into a {@link Series} of groups according to a user-defined selector function.
      *
-     * @param selector User-defined selector function that specifies the criteriay to group by.
+     * @param selector User-defined selector function that specifies the criteria to group by.
      *
      * @return Returns a {@link Series} of groups. Each group is a dataframe with rows that have been grouped by the 'selector' function.
      * 
@@ -2773,7 +2773,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
     }
 
     //
-    // Ensure the dataframe content is lazy initalised and return it.
+    // Ensure the dataframe content is lazy initialised and return it.
     //
     private getContent(): IDataFrameContent<IndexT, ValueT> { 
         this.lazyInit();
@@ -2822,7 +2822,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
      * @example
      * <pre>
      * 
-     * for (const column in df.getColummns()) {
+     * for (const column in df.getColumns()) {
      *      console.log("Column name: ");
      *      console.log(column.name);
      * 
@@ -3420,7 +3420,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
      * 
      * @param columnNames Specifies the new order for columns.
      * 
-     * @return Returns a new dataframe with columns reodered according to the order of the array of column names that is passed in.
+     * @return Returns a new dataframe with columns reordered according to the order of the array of column names that is passed in.
      * 
      * @example
      * <pre>
@@ -3536,7 +3536,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
      * 
      * @example
      * <pre>
-     * const modifiedDf = df.bringToBack(["NewSecondLastCollumn, ""NewLastColumn"]);
+     * const modifiedDf = df.bringToBack(["NewSecondLastColumn, ""NewLastColumn"]);
      * </pre>
      */
     bringToBack (columnOrColumns: string | string[]): IDataFrame<IndexT, ValueT> {
@@ -3710,7 +3710,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
      * 
      * const someObject = df.toObject(
      *      row => row.SomeColumn, // Specify the column to use for fields in the object.
-     *      row => row.SomeOtherColumn // Specifi the column to use as the value for each field.
+     *      row => row.SomeOtherColumn // Specify the column to use as the value for each field.
      * );
      * </pre>
      */
@@ -4131,7 +4131,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
      * Eliminates adjacent duplicate rows.
      * 
      * For each group of adjacent rows that are equivalent only returns the last index/row for the group, 
-     * thus ajacent equivalent rows are collapsed down to the last row.
+     * thus adjacent equivalent rows are collapsed down to the last row.
      *
      * @param [selector] Optional selector function to determine the value used to compare for equivalence.
      * 
@@ -4706,7 +4706,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
         else {
             // Just check if empty.
             const iterator = this[Symbol.iterator]()
-            return iterator.next().done;
+            return iterator.next().done || false;
         }
 
         return true; // Nothing failed the predicate.
@@ -5624,7 +5624,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
      * This is basically a concatenation and then elimination of duplicates.
      *
      * @param other The other dataframes to merge.
-     * @param [selector] Optional user-defined selector function that selects the value to compare to detemrine distinctness.
+     * @param [selector] Optional user-defined selector function that selects the value to compare to determine distinctness.
      * 
      * @return Returns the union of the two dataframes.
      * 
@@ -6269,7 +6269,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
 
         if (!isObject(valueColumnNameOrSpec)) {
             if (!isString(valueColumnNameOrSpec)) throw new Error("Expected 'value' parameter to 'DataFrame.pivot' to be a string that identifies the column whose values to aggregate or a column spec that defines which column contains the value ot aggregate and the ways to aggregate that value.");
-            if (!isFunction(aggregator)) throw new Error("Expected 'aggregator' parameter to 'DataFrame.pivot' to be a function to aggegrate pivoted values.");
+            if (!isFunction(aggregator)) throw new Error("Expected 'aggregator' parameter to 'DataFrame.pivot' to be a function to aggregate pivoted values.");
 
             const aggColumnName = valueColumnNameOrSpec as string;
 


### PR DESCRIPTION
An attempt to fix https://github.com/data-forge/data-forge-ts/issues/24

Surely this wouldn't work for indexes of type other than of `string[]` or `number[]` - not sure it's a real concern.