### PR TITLE
add the flag caseSensitive in dataframe to treat columnNames as Casesensitive

### DIFF
--- a/src/lib/dataframe.ts
+++ b/src/lib/dataframe.ts
@@ -153,6 +153,13 @@ export interface IDataFrameConfig<IndexT, ValueT> {
      * Explicitly specify data for named columns to put in the dataframe.
      */
     columns?: Iterable<IColumnConfig> | IColumnSpec,
+
+    /**
+     * Explicitly set this value if you want columnNames to be caseSensitive.
+     * Default behaviour is to treat column names as case insensitive
+     */
+
+    caseSensitive?: boolean,
 }
 
 /** 
@@ -2598,13 +2605,14 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
     //
     // Initialise dataframe column names.
     //
-    private static initColumnNames(inputColumnNames: Iterable<string>): Iterable<string> {
+    private static initColumnNames(inputColumnNames: Iterable<string>, isCaseSensitive?: boolean): Iterable<string> {
         const outputColumnNames: string[] = [];
         const columnNamesMap: any = {};
     
         // Search for duplicate column names.
         for (const columnName of inputColumnNames) {
-            const columnNameLwr = columnName.toLowerCase();
+            const columnNameLwr = isCaseSensitive !== undefined  && isCaseSensitive ? columnName : columnName.toLowerCase();
+
             if (columnNamesMap[columnNameLwr] === undefined) {
                 columnNamesMap[columnNameLwr] = 1;
             }
@@ -2616,7 +2624,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
         const columnNoMap: any = {};
 
         for (const columnName of inputColumnNames) {
-            const columnNameLwr = columnName.toLowerCase();
+            const columnNameLwr = isCaseSensitive !== undefined  && isCaseSensitive ? columnName : columnName.toLowerCase();
             if (columnNamesMap[columnNameLwr] > 1) {
                 let curColumnNo = 1;
 
@@ -2696,7 +2704,7 @@ export class DataFrame<IndexT = number, ValueT = any> implements IDataFrame<Inde
         }
         else {
             if (config.columnNames) {
-                columnNames = this.initColumnNames(config.columnNames);
+                columnNames = this.initColumnNames(config.columnNames, config.caseSensitive);
             }
 
             if (config.rows) {

--- a/src/test/dataframe.columns.test.ts
+++ b/src/test/dataframe.columns.test.ts
@@ -351,6 +351,87 @@ describe('DataFrame columns', () => {
 		]);
 	});
 
+    it('case sensitive columns are renamed to be unique with caseSensitive' , () => {
+
+		var df = new DataFrame({
+			columnNames: [
+				"some-column",
+				"some-Column",
+			],
+			rows: [
+				[1, 2],
+				[3, 4],
+            ],
+            caseSensitive: false,
+		});
+
+		expect(df.getColumnNames()).to.eql(["some-column.1", "some-Column.2"]);
+		expect(df.toArray()).to.eql([
+			{
+				"some-column.1": 1,
+				"some-Column.2": 2,
+			},
+			{
+				"some-column.1": 3,
+				"some-Column.2": 4,
+			},
+		]);
+    });
+       
+    it('duplicates columns are renamed to be unique with caseSensitive', () => {
+
+		var df = new DataFrame({
+			columnNames: [
+				"some-column",
+				"some-column",
+			],
+			rows: [
+				[1, 2],
+				[3, 4],
+            ],
+            caseSensitive: true,
+		});
+
+		expect(df.getColumnNames()).to.eql(["some-column.1", "some-column.2"]);
+		expect(df.toArray()).to.eql([
+			{
+				"some-column.1": 1,
+				"some-column.2": 2,
+			},
+			{
+				"some-column.1": 3,
+				"some-column.2": 4,
+			},
+		]);
+    });
+
+    it('case sensitive columns are treated as unique with caseSensitive' , () => {
+
+		var df = new DataFrame({
+			columnNames: [
+				"some-column",
+				"some-Column",
+			],
+			rows: [
+				[1, 2],
+				[3, 4],
+            ],
+            caseSensitive: true,
+		});
+
+		expect(df.getColumnNames()).to.eql(["some-column", "some-Column"]);
+		expect(df.toArray()).to.eql([
+			{
+				"some-column": 1,
+				"some-Column": 2,
+			},
+			{
+				"some-column": 3,
+				"some-Column": 4,
+			},
+		]);
+    });
+
 	it('can check that column exists', () => {
 		
 		var dataFrame = new DataFrame({


### PR DESCRIPTION
Added a caseSensitive flag in the `IDataFrameConfig` to handle the default behaviour of converting columnNames toLowerCase in the `initColumnNames` function

Added the tests in the `dataframe.columns.test.ts`