### PR TITLE
fix: do not use deprecated Node.js util.isFunction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,7 @@ import { ArrayIterable } from './lib/iterables/array-iterable';
 import { CsvRowsIterable } from './lib/iterables/csv-rows-iterable';
 import { Series, ISeries } from '.';
 import { DataFrame, IDataFrame } from '.';
-import { isString, isObject, isArray, isNumber } from './lib/utils';
-import { isFunction } from 'util';
+import { isString, isObject, isArray, isNumber, isFunction } from './lib/utils';
 import JSON5 from 'json5';
 // @ts-ignore
 import moment from "dayjs";


### PR DESCRIPTION
Hi,

the [`util.isFunction`](https://nodejs.org/docs/latest-v22.x/api/util.html#utilisfunctionobject) function from Node.js has been deprecated since v4 and recently removed in v24.

The following code does thus no longer in Node v24:

```ts
import * as dataForge from "data-forge";

dataForge.fromCsv(/* ... */)
```

It fails with a `TypeError: util_1.isFunction is not a function` error message.

This PR should fix that by using the `isFunction` function from the `src/lib/utils.ts` file.